### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "ryancramerdesign/file-validator-svg-sanitizer",
+  "license": "MIT",
+  "type": "pw-module",
+  "require": {
+    "wireframe-framework/processwire-composer-installer": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Add composer.json for Composer installation support.

Note: the module should also be added to Packagist to make installation easier.